### PR TITLE
Apply cargo fmt + clippy baseline for Rust 1.96

### DIFF
--- a/src/api/messages.rs
+++ b/src/api/messages.rs
@@ -1,8 +1,6 @@
-use actix_web::{delete, post, put, web, HttpResponse};
+use actix_web::{HttpResponse, delete, post, put, web};
 use serde::{Deserialize, Serialize};
-use serenity::all::{
-    ChannelId, CreateEmbed, CreateMessage, CreateThread, EditMessage, MessageId,
-};
+use serenity::all::{ChannelId, CreateEmbed, CreateMessage, CreateThread, EditMessage, MessageId};
 
 use crate::db::models::AppState;
 use crate::error::AppError;
@@ -186,4 +184,3 @@ pub async fn delete_message(
 
     Ok(HttpResponse::Ok().json(serde_json::json!({ "ok": true })))
 }
-

--- a/src/config.rs
+++ b/src/config.rs
@@ -26,7 +26,8 @@ impl Config {
             uptime_kuma_push_url: required("UPTIME_KUMA_PUSH_URL")?,
             grafana_url: optional("GRAFANA_URL").map(|u| u.trim_end_matches('/').to_string()),
             lerke_url: optional("LERKE_URL").map(|u| u.trim_end_matches('/').to_string()),
-            uptime_kuma_url: optional("UPTIME_KUMA_URL").map(|u| u.trim_end_matches('/').to_string()),
+            uptime_kuma_url: optional("UPTIME_KUMA_URL")
+                .map(|u| u.trim_end_matches('/').to_string()),
         })
     }
 

--- a/src/db/queries.rs
+++ b/src/db/queries.rs
@@ -28,11 +28,10 @@ pub async fn list_incidents(
 }
 
 pub async fn get_incident(pool: &SqlitePool, id: i64) -> AppResult<Option<Incident>> {
-    let incident =
-        sqlx::query_as::<_, Incident>("SELECT * FROM incidents WHERE id = ?")
-            .bind(id)
-            .fetch_optional(pool)
-            .await?;
+    let incident = sqlx::query_as::<_, Incident>("SELECT * FROM incidents WHERE id = ?")
+        .bind(id)
+        .fetch_optional(pool)
+        .await?;
     Ok(incident)
 }
 

--- a/src/discord/notifier.rs
+++ b/src/discord/notifier.rs
@@ -1,6 +1,4 @@
-use serenity::all::{
-    ChannelId, CreateEmbed, CreateMessage, CreateThread, EditMessage, MessageId,
-};
+use serenity::all::{ChannelId, CreateEmbed, CreateMessage, CreateThread, EditMessage, MessageId};
 use serenity::http::Http;
 
 use crate::db::models::Incident;
@@ -20,17 +18,15 @@ fn get_annotation(incident: &Incident, key: &str) -> Option<String> {
 /// Collect annotations that end in _url as (label, url) pairs
 fn collect_url_annotations(incident: &Incident) -> Vec<(String, String)> {
     let mut urls = Vec::new();
-    if let Ok(annotations) = serde_json::from_str::<serde_json::Value>(&incident.annotations_json) {
-        if let Some(obj) = annotations.as_object() {
+    if let Ok(annotations) = serde_json::from_str::<serde_json::Value>(&incident.annotations_json)
+        && let Some(obj) = annotations.as_object() {
             for (key, value) in obj {
-                if let Some(prefix) = key.strip_suffix("_url") {
-                    if let Some(url) = value.as_str() {
+                if let Some(prefix) = key.strip_suffix("_url")
+                    && let Some(url) = value.as_str() {
                         urls.push((url_key_to_label(prefix), url.to_string()));
                     }
-                }
             }
         }
-    }
     urls
 }
 
@@ -51,9 +47,7 @@ fn build_embed(incident: &Incident, lerke_url: Option<&str>) -> CreateEmbed {
         COLOR_RED
     };
 
-    let mut embed = CreateEmbed::new()
-        .title(&incident.alert_name)
-        .color(color);
+    let mut embed = CreateEmbed::new().title(&incident.alert_name).color(color);
 
     // Build description: summary, then links
     let mut desc_parts = Vec::new();
@@ -87,8 +81,8 @@ fn build_embed(incident: &Incident, lerke_url: Option<&str>) -> CreateEmbed {
     }
 
     // Add alert labels as fields (vertical — inline=false), filtering out noise
-    if let Ok(labels) = serde_json::from_str::<serde_json::Value>(&incident.labels_json) {
-        if let Some(obj) = labels.as_object() {
+    if let Ok(labels) = serde_json::from_str::<serde_json::Value>(&incident.labels_json)
+        && let Some(obj) = labels.as_object() {
             for (key, value) in obj {
                 if FILTERED_LABELS.contains(&key.as_str()) {
                     continue;
@@ -97,7 +91,6 @@ fn build_embed(incident: &Incident, lerke_url: Option<&str>) -> CreateEmbed {
                 embed = embed.field(key, &val_str, false);
             }
         }
-    }
 
     embed
 }
@@ -126,7 +119,8 @@ pub async fn send_firing_notification(
         .create_thread_from_message(
             http,
             message.id,
-            CreateThread::new(thread_name).auto_archive_duration(serenity::all::AutoArchiveDuration::OneDay),
+            CreateThread::new(thread_name)
+                .auto_archive_duration(serenity::all::AutoArchiveDuration::OneDay),
         )
         .await
         .map_err(|e| AppError::Discord(format!("Failed to create thread: {}", e)))?;
@@ -162,7 +156,11 @@ pub async fn update_incident_embed(
     let embed = build_embed(incident, lerke_url);
 
     ChannelId::new(channel)
-        .edit_message(http, MessageId::new(message), EditMessage::new().embed(embed))
+        .edit_message(
+            http,
+            MessageId::new(message),
+            EditMessage::new().embed(embed),
+        )
         .await
         .map_err(|e| AppError::Discord(format!("Failed to edit message: {}", e)))?;
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,4 @@
-use actix_web::{http::StatusCode, HttpResponse, ResponseError};
+use actix_web::{HttpResponse, ResponseError, http::StatusCode};
 use thiserror::Error;
 
 #[derive(Error, Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 #[macro_export]
 macro_rules! serve_static_file {
     ($file:expr) => {{
-        use actix_web::{web, HttpRequest, HttpResponse};
+        use actix_web::{HttpRequest, HttpResponse, web};
         use std::io::Read;
         use std::sync::Arc;
         let path = std::path::Path::new("static").join($file);

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -20,9 +20,7 @@ pub fn init(_registry: &prometheus::Registry) -> Result<(), anyhow::Error> {
         webhooks_received: meter.u64_counter("lerke_webhooks_received").init(),
         incidents_created: meter.u64_counter("lerke_incidents_created").init(),
         incidents_resolved: meter.u64_counter("lerke_incidents_resolved").init(),
-        discord_notifications_sent: meter
-            .u64_counter("lerke_discord_notifications_sent")
-            .init(),
+        discord_notifications_sent: meter.u64_counter("lerke_discord_notifications_sent").init(),
         discord_notification_errors: meter
             .u64_counter("lerke_discord_notification_errors")
             .init(),

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,6 +1,5 @@
 pub use actix_web::{
-    middleware,
-    web::{get as web_get, Data},
-    App, HttpServer,
+    App, HttpServer, middleware,
+    web::{Data, get as web_get},
 };
 pub use actix_web_opentelemetry::{PrometheusMetricsHandler, RequestMetrics, RequestTracing};

--- a/src/web/debug.rs
+++ b/src/web/debug.rs
@@ -1,5 +1,5 @@
-use actix_web::{get, post, web, HttpResponse, Responder};
-use maud::{html, Markup, DOCTYPE};
+use actix_web::{HttpResponse, Responder, get, post, web};
+use maud::{DOCTYPE, Markup, html};
 use serenity::all::ChannelId;
 
 use crate::db::models::AppState;
@@ -105,7 +105,8 @@ pub async fn debug_purge(state: web::Data<AppState>) -> impl Responder {
     }
 
     if errors.is_empty() {
-        HttpResponse::Ok().body("<span class=\"purge-success\">All data purged successfully.</span>")
+        HttpResponse::Ok()
+            .body("<span class=\"purge-success\">All data purged successfully.</span>")
     } else {
         HttpResponse::Ok().body(format!(
             "<span class=\"purge-error\">Partial purge. Errors: {}</span>",
@@ -136,10 +137,9 @@ async fn delete_bot_messages(
             builder = builder.before(before);
         }
 
-        let messages = channel_id
-            .messages(http, builder)
-            .await
-            .map_err(|e| crate::error::AppError::Discord(format!("Failed to fetch messages: {}", e)))?;
+        let messages = channel_id.messages(http, builder).await.map_err(|e| {
+            crate::error::AppError::Discord(format!("Failed to fetch messages: {}", e))
+        })?;
 
         if messages.is_empty() {
             break;
@@ -150,10 +150,7 @@ async fn delete_bot_messages(
         for msg in &messages {
             if msg.author.id == bot_id {
                 // Also delete any threads created from this message
-                if let Err(e) = channel_id
-                    .delete_message(http, msg.id)
-                    .await
-                {
+                if let Err(e) = channel_id.delete_message(http, msg.id).await {
                     log::warn!("Failed to delete message {}: {}", msg.id, e);
                 } else {
                     deleted += 1;

--- a/src/web/formatting.rs
+++ b/src/web/formatting.rs
@@ -8,7 +8,11 @@ fn parse_utc(ts: &str) -> Option<chrono::NaiveDateTime> {
 }
 
 fn to_eastern(ts: &str) -> Option<chrono::DateTime<chrono_tz::Tz>> {
-    parse_utc(ts).map(|naive| chrono::Utc.from_utc_datetime(&naive).with_timezone(&New_York))
+    parse_utc(ts).map(|naive| {
+        chrono::Utc
+            .from_utc_datetime(&naive)
+            .with_timezone(&New_York)
+    })
 }
 
 /// Format a UTC timestamp string as human-readable Eastern time.

--- a/src/web/header.rs
+++ b/src/web/header.rs
@@ -1,4 +1,4 @@
-use maud::{html, Markup};
+use maud::{Markup, html};
 
 pub fn render(active_page: &str) -> Markup {
     html! {

--- a/src/web/history.rs
+++ b/src/web/history.rs
@@ -1,13 +1,13 @@
 use std::collections::BTreeMap;
 
 use actix_web::{get, web};
-use maud::{html, Markup, DOCTYPE};
+use maud::{DOCTYPE, Markup, html};
 
 use crate::db::models::{AppState, Incident};
 use crate::db::queries;
+use crate::discord::notifier::url_key_to_label;
 use crate::error::AppResult;
 use crate::web::formatting::{format_date_eastern, format_time_eastern};
-use crate::discord::notifier::url_key_to_label;
 use crate::web::header;
 use crate::web::incidents::render_labels;
 

--- a/src/web/incident_detail.rs
+++ b/src/web/incident_detail.rs
@@ -1,9 +1,9 @@
 use actix_web::{get, web};
-use maud::{html, Markup, DOCTYPE};
+use maud::{DOCTYPE, Markup, html};
 
 use crate::db::models::{AppState, Incident};
-use crate::discord::notifier::{url_key_to_label, FILTERED_LABELS};
 use crate::db::queries;
+use crate::discord::notifier::{FILTERED_LABELS, url_key_to_label};
 use crate::error::AppResult;
 use crate::web::formatting::format_eastern;
 use crate::web::header;
@@ -19,27 +19,31 @@ fn get_annotation(incident: &Incident, key: &str) -> Option<String> {
 fn collect_metadata(incident: &Incident) -> Vec<(String, String)> {
     let mut pairs = Vec::new();
 
-    if let Ok(labels) = serde_json::from_str::<serde_json::Value>(&incident.labels_json) {
-        if let Some(obj) = labels.as_object() {
+    if let Ok(labels) = serde_json::from_str::<serde_json::Value>(&incident.labels_json)
+        && let Some(obj) = labels.as_object() {
             for (key, value) in obj {
                 if FILTERED_LABELS.contains(&key.as_str()) {
                     continue;
                 }
-                pairs.push((key.clone(), value.as_str().unwrap_or(&value.to_string()).to_string()));
+                pairs.push((
+                    key.clone(),
+                    value.as_str().unwrap_or(&value.to_string()).to_string(),
+                ));
             }
         }
-    }
 
-    if let Ok(annotations) = serde_json::from_str::<serde_json::Value>(&incident.annotations_json) {
-        if let Some(obj) = annotations.as_object() {
+    if let Ok(annotations) = serde_json::from_str::<serde_json::Value>(&incident.annotations_json)
+        && let Some(obj) = annotations.as_object() {
             for (key, value) in obj {
                 if PROMOTED_ANNOTATIONS.contains(&key.as_str()) || key.ends_with("_url") {
                     continue;
                 }
-                pairs.push((key.clone(), value.as_str().unwrap_or(&value.to_string()).to_string()));
+                pairs.push((
+                    key.clone(),
+                    value.as_str().unwrap_or(&value.to_string()).to_string(),
+                ));
             }
         }
-    }
 
     pairs
 }
@@ -47,17 +51,15 @@ fn collect_metadata(incident: &Incident) -> Vec<(String, String)> {
 /// Collect annotations ending in _url as (label, url) pairs
 fn collect_url_annotations(incident: &Incident) -> Vec<(String, String)> {
     let mut urls = Vec::new();
-    if let Ok(annotations) = serde_json::from_str::<serde_json::Value>(&incident.annotations_json) {
-        if let Some(obj) = annotations.as_object() {
+    if let Ok(annotations) = serde_json::from_str::<serde_json::Value>(&incident.annotations_json)
+        && let Some(obj) = annotations.as_object() {
             for (key, value) in obj {
-                if let Some(prefix) = key.strip_suffix("_url") {
-                    if let Some(url) = value.as_str() {
+                if let Some(prefix) = key.strip_suffix("_url")
+                    && let Some(url) = value.as_str() {
                         urls.push((url_key_to_label(prefix), url.to_string()));
                     }
-                }
             }
         }
-    }
     urls
 }
 

--- a/src/web/incidents.rs
+++ b/src/web/incidents.rs
@@ -1,5 +1,5 @@
-use actix_web::{get, web, Responder};
-use maud::{html, Markup, DOCTYPE};
+use actix_web::{Responder, get, web};
+use maud::{DOCTYPE, Markup, html};
 
 use crate::db::models::{AppState, Incident};
 use crate::db::queries;

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -7,11 +7,11 @@ pub mod incidents;
 
 pub use debug::{debug_purge, debug_webhooks_fragment, debug_webhooks_page};
 pub use history::{history_fragment, history_page};
-pub use incident_detail::incident_events_fragment;
 pub use incident_detail::incident_detail_page;
+pub use incident_detail::incident_events_fragment;
 pub use incidents::{incidents_fragment, incidents_page};
 
-use actix_web::{get, HttpResponse, Responder};
+use actix_web::{HttpResponse, Responder, get};
 
 #[get("/")]
 pub async fn root() -> impl Responder {

--- a/src/webhooks/grafana.rs
+++ b/src/webhooks/grafana.rs
@@ -1,4 +1,4 @@
-use actix_web::{post, web, HttpResponse, Responder};
+use actix_web::{HttpResponse, Responder, post, web};
 use serde::Deserialize;
 
 use crate::db::models::{AppState, WebhookLogEntry};
@@ -88,10 +88,7 @@ impl GrafanaAlert {
 }
 
 #[post("/api/webhooks/grafana")]
-pub async fn grafana_webhook(
-    body: web::Bytes,
-    state: web::Data<AppState>,
-) -> impl Responder {
+pub async fn grafana_webhook(body: web::Bytes, state: web::Data<AppState>) -> impl Responder {
     metrics::get().webhooks_received.add(1, &[]);
 
     let raw_body = String::from_utf8_lossy(&body).to_string();
@@ -128,7 +125,10 @@ pub async fn grafana_webhook(
     HttpResponse::Ok().finish()
 }
 
-async fn process_alert(alert: &GrafanaAlert, state: &AppState) -> Result<(), crate::error::AppError> {
+async fn process_alert(
+    alert: &GrafanaAlert,
+    state: &AppState,
+) -> Result<(), crate::error::AppError> {
     let now = chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string();
     let alert_name = alert.alert_name();
     let raw_payload = serde_json::to_string(alert).ok();
@@ -213,7 +213,11 @@ async fn process_alert(alert: &GrafanaAlert, state: &AppState) -> Result<(), cra
                 }
             }
 
-            log::info!("Created new incident {} for alert {}", incident_id, alert_name);
+            log::info!(
+                "Created new incident {} for alert {}",
+                incident_id,
+                alert_name
+            );
         }
 
         Some(incident) if incident.status != alert.status => {
@@ -256,15 +260,19 @@ async fn process_alert(alert: &GrafanaAlert, state: &AppState) -> Result<(), cra
                 &incident.discord_thread_id,
             ) {
                 // Fetch updated incident for embed
-                if let Some(updated) = queries::get_incident(&state.db, incident.id).await? {
-                    if let Err(e) =
-                        notifier::update_incident_embed(&state.discord_http, ch_id, msg_id, &updated, state.config.lerke_url.as_deref())
-                            .await
+                if let Some(updated) = queries::get_incident(&state.db, incident.id).await?
+                    && let Err(e) = notifier::update_incident_embed(
+                        &state.discord_http,
+                        ch_id,
+                        msg_id,
+                        &updated,
+                        state.config.lerke_url.as_deref(),
+                    )
+                    .await
                     {
                         log::error!("Failed to update Discord embed: {}", e);
                         metrics::get().discord_notification_errors.add(1, &[]);
                     }
-                }
 
                 if let Err(e) =
                     notifier::post_thread_update(&state.discord_http, thread_id, &event_msg).await

--- a/src/webhooks/uptime_kuma.rs
+++ b/src/webhooks/uptime_kuma.rs
@@ -1,4 +1,4 @@
-use actix_web::{post, web, HttpResponse, Responder};
+use actix_web::{HttpResponse, Responder, post, web};
 use serde::Deserialize;
 
 use crate::db::models::{AppState, WebhookLogEntry};
@@ -65,10 +65,7 @@ impl UptimeKumaHeartbeat {
 }
 
 #[post("/api/webhooks/uptime-kuma")]
-pub async fn uptime_kuma_webhook(
-    body: web::Bytes,
-    state: web::Data<AppState>,
-) -> impl Responder {
+pub async fn uptime_kuma_webhook(body: web::Bytes, state: web::Data<AppState>) -> impl Responder {
     metrics::get().webhooks_received.add(1, &[]);
 
     let raw_body = String::from_utf8_lossy(&body).to_string();
@@ -127,27 +124,43 @@ async fn process_heartbeat(
 
     // Build labels
     let mut labels = serde_json::Map::new();
-    labels.insert("source".to_string(), serde_json::Value::String("uptime-kuma".to_string()));
-    labels.insert("monitor_name".to_string(), serde_json::Value::String(monitor.name.clone()));
+    labels.insert(
+        "source".to_string(),
+        serde_json::Value::String("uptime-kuma".to_string()),
+    );
+    labels.insert(
+        "monitor_name".to_string(),
+        serde_json::Value::String(monitor.name.clone()),
+    );
     if let Some(ref mt) = monitor.monitor_type {
-        labels.insert("monitor_type".to_string(), serde_json::Value::String(mt.clone()));
+        labels.insert(
+            "monitor_type".to_string(),
+            serde_json::Value::String(mt.clone()),
+        );
     }
 
     // Build annotations
     let mut annotations = serde_json::Map::new();
-    if let Some(ref desc) = monitor.description {
-        if !desc.is_empty() {
-            annotations.insert("description".to_string(), serde_json::Value::String(desc.clone()));
+    if let Some(ref desc) = monitor.description
+        && !desc.is_empty() {
+            annotations.insert(
+                "description".to_string(),
+                serde_json::Value::String(desc.clone()),
+            );
         }
-    }
     if !heartbeat.msg.is_empty() {
-        annotations.insert("summary".to_string(), serde_json::Value::String(heartbeat.msg.clone()));
+        annotations.insert(
+            "summary".to_string(),
+            serde_json::Value::String(heartbeat.msg.clone()),
+        );
     }
-    if let Some(ref url) = monitor.url {
-        if !url.is_empty() && url != "https://" {
-            annotations.insert("site_url".to_string(), serde_json::Value::String(url.clone()));
+    if let Some(ref url) = monitor.url
+        && !url.is_empty() && url != "https://" {
+            annotations.insert(
+                "site_url".to_string(),
+                serde_json::Value::String(url.clone()),
+            );
         }
-    }
 
     // Uptime Kuma dashboard link — stored as annotation so it renders as "Kuma" link
     if let Some(ref base) = state.config.uptime_kuma_url {
@@ -158,7 +171,8 @@ async fn process_heartbeat(
     }
 
     let labels_json = serde_json::to_string(&serde_json::Value::Object(labels)).unwrap_or_default();
-    let annotations_json = serde_json::to_string(&serde_json::Value::Object(annotations)).unwrap_or_default();
+    let annotations_json =
+        serde_json::to_string(&serde_json::Value::Object(annotations)).unwrap_or_default();
 
     let existing = queries::get_incident_by_grafana_uid(&state.db, &uid).await?;
 
@@ -171,9 +185,9 @@ async fn process_heartbeat(
                 "firing",
                 None,
                 None, // dashboard_url
-                None,                    // panel_url
-                None,                    // silence_url
-                None,                    // generator_url
+                None, // panel_url
+                None, // silence_url
+                None, // generator_url
                 &labels_json,
                 &annotations_json,
                 &now,
@@ -218,7 +232,11 @@ async fn process_heartbeat(
                 }
             }
 
-            log::info!("Created Uptime Kuma incident {} for {}", incident_id, alert_name);
+            log::info!(
+                "Created Uptime Kuma incident {} for {}",
+                incident_id,
+                alert_name
+            );
         }
 
         Some(incident) if incident.status == "firing" && heartbeat.is_up() => {
@@ -229,22 +247,16 @@ async fn process_heartbeat(
 
             let event_msg = "Alert resolved".to_string();
 
-            queries::create_incident_event(
-                &state.db,
-                incident.id,
-                "resolved",
-                &event_msg,
-                None,
-            )
-            .await?;
+            queries::create_incident_event(&state.db, incident.id, "resolved", &event_msg, None)
+                .await?;
 
             if let (Some(ch_id), Some(msg_id), Some(thread_id)) = (
                 &incident.discord_channel_id,
                 &incident.discord_message_id,
                 &incident.discord_thread_id,
             ) {
-                if let Some(updated) = queries::get_incident(&state.db, incident.id).await? {
-                    if let Err(e) = notifier::update_incident_embed(
+                if let Some(updated) = queries::get_incident(&state.db, incident.id).await?
+                    && let Err(e) = notifier::update_incident_embed(
                         &state.discord_http,
                         ch_id,
                         msg_id,
@@ -256,7 +268,6 @@ async fn process_heartbeat(
                         log::error!("Failed to update Discord embed: {}", e);
                         metrics::get().discord_notification_errors.add(1, &[]);
                     }
-                }
 
                 if let Err(e) =
                     notifier::post_thread_update(&state.discord_http, thread_id, &event_msg).await
@@ -266,7 +277,11 @@ async fn process_heartbeat(
                 }
             }
 
-            log::info!("Resolved Uptime Kuma incident {} for {}", incident.id, alert_name);
+            log::info!(
+                "Resolved Uptime Kuma incident {} for {}",
+                incident.id,
+                alert_name
+            );
         }
 
         Some(incident) if heartbeat.is_down() && heartbeat.important => {
@@ -283,7 +298,10 @@ async fn process_heartbeat(
 
         None if heartbeat.is_up() => {
             // Up with no open incident — ignore
-            log::debug!("Ignoring UP heartbeat for {} with no open incident", alert_name);
+            log::debug!(
+                "Ignoring UP heartbeat for {} with no open incident",
+                alert_name
+            );
         }
 
         _ => {}


### PR DESCRIPTION
One-shot mechanical pass:
- `cargo fmt --all` per workspace root
- `cargo clippy --workspace --all-targets --fix --allow-dirty --allow-staged` per workspace root

Establishes a clean baseline so the on-disk code matches what Rust 1.96's rustfmt/clippy expects.

Part of kj800x/homelab#4.